### PR TITLE
Throw if same name fragment with different definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dkempner/persistgraphql",
-  "version": "0.3.11-patch.3",
+  "version": "0.3.11-patch.5",
   "description": "A build tool for GraphQL projects.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/ExtractGQL.ts
+++ b/src/ExtractGQL.ts
@@ -449,6 +449,7 @@ export const main = (argv: YArgsv) => {
   new ExtractGQL(options).extract();
 };
 
+// Below is copypasta'd from https://github.com/apollographql/graphql-tag/blob/main/src/index.ts#L31-L69
 // Strip insignificant whitespace
 // Note that this could do a lot more, such as reorder fields etc.
 function normalize(string: string) {


### PR DESCRIPTION
# What

Fixes #1

Throws the duplicate fragment error message if fragments don't have identical bodies.